### PR TITLE
fix: correct forgot password config field

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ var rootCmd = &cobra.Command{
 			GenericName:           config.GenericName,
 			CookieSecure:          config.CookieSecure,
 			Domain:                domain,
-			ForgotPasswordMessage: config.FogotPasswordMessage,
+			ForgotPasswordMessage: config.ForgotPasswordMessage,
 			BackgroundImage:       config.BackgroundImage,
 			OAuthAutoRedirect:     config.OAuthAutoRedirect,
 			CsrfCookieName:        csrfCookieName,

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -34,14 +34,15 @@ type Config struct {
 	EnvFile                 string `mapstructure:"env-file"`
 	LoginTimeout            int    `mapstructure:"login-timeout"`
 	LoginMaxRetries         int    `mapstructure:"login-max-retries"`
-	FogotPasswordMessage    string `mapstructure:"forgot-password-message"`
-	BackgroundImage         string `mapstructure:"background-image" validate:"required"`
-	LdapAddress             string `mapstructure:"ldap-address"`
-	LdapBindDN              string `mapstructure:"ldap-bind-dn"`
-	LdapBindPassword        string `mapstructure:"ldap-bind-password"`
-	LdapBaseDN              string `mapstructure:"ldap-base-dn"`
-	LdapInsecure            bool   `mapstructure:"ldap-insecure"`
-	LdapSearchFilter        string `mapstructure:"ldap-search-filter"`
+	// ForgotPasswordMessage is the message displayed on the forgot password page.
+	ForgotPasswordMessage string `mapstructure:"forgot-password-message"`
+	BackgroundImage       string `mapstructure:"background-image" validate:"required"`
+	LdapAddress           string `mapstructure:"ldap-address"`
+	LdapBindDN            string `mapstructure:"ldap-bind-dn"`
+	LdapBindPassword      string `mapstructure:"ldap-bind-password"`
+	LdapBaseDN            string `mapstructure:"ldap-base-dn"`
+	LdapInsecure          bool   `mapstructure:"ldap-insecure"`
+	LdapSearchFilter      string `mapstructure:"ldap-search-filter"`
 }
 
 // Server configuration


### PR DESCRIPTION
## Summary
- fix typo in config field `ForgotPasswordMessage`
- use the corrected field in root command handler

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68952470b6e083278ebaddb33aa29ef0