### PR TITLE
fix: retain domain when no subdomain

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -51,7 +51,13 @@ func GetUpperDomain(urlSrc string) (string, error) {
 		return "", err
 	}
 
-	urlSplitted := strings.Split(urlParsed.Hostname(), ".")
+	host := urlParsed.Hostname()
+	urlSplitted := strings.Split(host, ".")
+
+	if len(urlSplitted) <= 2 {
+		return host, nil
+	}
+
 	urlFinal := strings.Join(urlSplitted[1:], ".")
 
 	return urlFinal, nil

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -50,6 +50,22 @@ func TestGetUpperDomain(t *testing.T) {
 	}
 }
 
+func TestGetUpperDomainNoSubdomain(t *testing.T) {
+	t.Log("Testing get upper domain with no subdomain")
+
+	url := "https://domain.com"
+	expected := "domain.com"
+
+	result, err := utils.GetUpperDomain(url)
+	if err != nil {
+		t.Fatalf("Error getting root url: %v", err)
+	}
+
+	if expected != result {
+		t.Fatalf("Expected %v, got %v", expected, result)
+	}
+}
+
 func TestReadFile(t *testing.T) {
 	t.Log("Creating a test file")
 


### PR DESCRIPTION
## Summary
- ensure `GetUpperDomain` returns the full domain when no subdomain is present
- add test for URLs without subdomains

## Testing
- `go test ./internal/utils -v`


------
https://chatgpt.com/codex/tasks/task_e_68952247d32c8327989e5439db896488